### PR TITLE
Accept the version as an optional parameter

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -10,10 +10,11 @@ type Options struct {
 	ClusterID string
 	ServerID  string
 	URL       string
+	Version   string
 }
 
 func StartReporter(ctx context.Context, opt Options) error {
-	reporter, err := usage.New(opt.URL, opt.ClusterID, opt.ServerID)
+	reporter, err := usage.New(opt.URL, opt.ClusterID, opt.ServerID, opt.Version)
 	if err != nil {
 		return err
 	}

--- a/usage.go
+++ b/usage.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/catalinc/hashcash"
-	"github.com/devopsfaith/krakend/core"
 )
 
 const (
@@ -96,9 +95,10 @@ type Reporter struct {
 	start     time.Time
 	minter    Minter
 	token     string
+	version   string
 }
 
-func New(url, clusterID, serverID string) (*Reporter, error) {
+func New(url, clusterID, serverID, Version string) (*Reporter, error) {
 	if url == "" {
 		url = defaultURL
 	}
@@ -127,6 +127,7 @@ func New(url, clusterID, serverID string) (*Reporter, error) {
 		token:     ses.Token,
 		clusterID: clusterID,
 		serverID:  serverID,
+		version:   Version,
 	}
 
 	return r, nil
@@ -146,7 +147,7 @@ func (r *Reporter) Report(ctx context.Context) {
 
 func (r *Reporter) SingleReport(ctx context.Context) error {
 	ud := UsageData{
-		Version:   core.KrakendVersion,
+		Version:   r.version,
 		Arch:      runtime.GOARCH,
 		OS:        runtime.GOOS,
 		ClusterID: r.clusterID,


### PR DESCRIPTION
Avoid the dependency on KrakenD core, so other Go project can use this module.

Notice: If the version is not specified it won't be present in the report, this is a breaking change for KrakenD maintainers.